### PR TITLE
Specify LeetTest Version to Use

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4.1.2
 
       - name: Test Solutions
-        run: npx --yes leettest
+        run: npx --yes leettest@0.1.0


### PR DESCRIPTION
This pull request resolves #9 by simply modifying the Test Solutions step in the CI workflow to specify the LeetTest version to be used.