### PR TITLE
Utilize LeetTest Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4.1.2
 
       - name: Test Solutions
-        run: npx --yes leettest@0.2.0
+        uses: threeal/leettest-action@v0.2.0


### PR DESCRIPTION
This pull request resolves #13 by utilizing the [LeetTest Action](https://github.com/threeal/leettest-action) in the CI workflow, replacing the direct call to the [leettest](https://www.npmjs.com/package/leettest) package with `npx`.